### PR TITLE
Implement checkpointing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@ The main steps are as follows:
 7. The final output is a CSV file containing AF2 structure path, evaluation parameters etc.
 
 ## Requirements  
-The script requires the prosculpt package. It assumes that RFdiffusion, proteinMPNN, and AF2 are installed and that the correct paths are provided in the `installation.yaml` config file. Additionally, os, glob, re, and shutil packages should be installed (these are all part of Python Standard Library and are pre-installed), as well as biopython, hydra-core, pandas.  
+The script requires the prosculpt package. It assumes that RFdiffusion, proteinMPNN, and AF2 are installed and that the correct paths are provided in the `installation.yaml` config file. Additionally, os, glob, re, and shutil packages should be installed (these are all part of Python Standard Library and are pre-installed), as well as biopython, hydra-core, pandas and scipy.  
+
+For running tests, Python version must be >= 3.7 (it needs the `capture_output` arg).
 
 # Using the new _merged code
 ## Installation
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install biopython hydra-core pandas
+pip install biopython hydra-core pandas scipy
 ```
 
 ## Usage

--- a/prosculpt.py
+++ b/prosculpt.py
@@ -671,8 +671,11 @@ def change_sequence_in_fasta (pdb_file, mpnn_fasta):
         seq_dict = {}
         for record in SeqIO.parse(mpnn_fasta, "fasta"):
             if i==0:
-                i +=1
-                continue
+                # Skip if record.description doesn't contain sample=. First seq is actually input to mpnn. However, after restart, we should not remove it again.
+                if "sample=" not in record.description:
+                    print(f"Skipping {record.description} for it does not contain sample=, it is input to and not output of mpnn.")
+                    i +=1
+                    continue
             i +=1
             print(record.seq, record.description)
             seq_dict[record.seq]=record.description

--- a/prosculpt.py
+++ b/prosculpt.py
@@ -53,7 +53,7 @@ def calculate_RMSD_linker_len (trb_path, af2_pdb, starting_pdb, rfdiff_pdb_path,
         if 'complex_con_ref_idx0' in trb_dict:
             selected_residues_data = trb_dict['complex_con_hal_idx0']
             selected_residues_in_designed_chains=trb_dict['con_hal_idx0']
-            if len(selected_residues_in_designed_chains) == 0 and trb_dict.config.contigmap.provide_seq!=None:
+            if len(selected_residues_in_designed_chains) == 0 and trb_dict["config"]["contigmap"]["provide_seq"]!=None:
                     selected_residues_in_designed_chains=np.where([a != b for a, b in zip(trb_dict["inpaint_seq"], trb_dict["inpaint_str"])])[0] #if this works...
                     print(f"DEBUG: PARTIAL DIFUSSION KEEPING RESIDUES {selected_residues_in_designed_chains}")
                     #print(selected_residues_in_designed_chains)

--- a/rfdiff_mpnn_af2_merged.py
+++ b/rfdiff_mpnn_af2_merged.py
@@ -485,7 +485,7 @@ def dtimelog(message, final=False):
     global TIMECALC
     global PREVIOUS_MESSAGE
     dt = round(time.time()-TIMECALC, 1)
-    log.warning(f"* * * {PREVIOUS_MESSAGE} lasted {dt} s. Running {message} * * *")
+    log.info(f"* * * {PREVIOUS_MESSAGE} lasted {dt} s. Running {message} * * *")
     TIMEMEASURES[PREVIOUS_MESSAGE] = dt
     PREVIOUS_MESSAGE = message
     TIMECALC = time.time()
@@ -493,7 +493,7 @@ def dtimelog(message, final=False):
     if final:
         # Print all measures one per line
         for k,v in TIMEMEASURES.items():
-            log.warning(f"{k} lasted {v} s.")
+            log.info(f"{k} lasted {v} s.")
 
 crash_at_error = 0 # Added through command line. Where should the test crash?
 crash_at_cycle = 0 # Added through command line. In which cycle should the test crash?

--- a/rfdiff_mpnn_af2_merged.py
+++ b/rfdiff_mpnn_af2_merged.py
@@ -189,7 +189,7 @@ def do_cycling(cfg):
                         af_model_num = prosculpt.get_token_value(os.path.basename(af2_pdb), "model_", "(\\d+)")
                         #if str(af_model_num) in args.af2_models:
                         # Rename pdbs to keep the model_num traceability with orginal rfdiff structure and enable filtering which models for next cycle
-                        if cycle == 1:
+                        if cycle >= 1:
                             rf_model_num = prosculpt.get_token_value(os.path.basename(model_subdict), "model_", "(\\d+)")
                             #else:
                                 #rf_model_num = prosculpt.get_token_value(os.path.basename(af2_pdb), "rf__", "(\\d+)") #after first cycling modelXX directories in af_output do not correspond to rf model anymore

--- a/rfdiff_mpnn_af2_merged.py
+++ b/rfdiff_mpnn_af2_merged.py
@@ -85,6 +85,18 @@ def run_rfdiff(cfg):
     See RFdiffusion git for details.
     """
     log.info("***************Running runRFdiff***************")
+
+    # Check if we already have cfg.num_designs_rfdiff .pdb and *.trb files in cfg.rfdiff_out_path
+    if len(glob.glob(os.path.join(cfg.rfdiff_out_path, "*.pdb"))) == cfg.num_designs_rfdiff:
+        log.info(f"Found {cfg.num_designs_rfdiff} .pdb and .trb files in {cfg.rfdiff_out_path}. Skipping RFdiff.")
+        if len(glob.glob(os.path.join(cfg.rfdiff_out_path, "*.trb"))) != cfg.num_designs_rfdiff:
+            log.critical(f"Found {len(glob.glob(os.path.join(cfg.rfdiff_out_path, '*.trb')))} trb files in {cfg.rfdiff_out_path}, expected {cfg.num_designs_rfdiff}. \n Most likely, your previous simulation crashed while RfDiff was writing output files. Please, manually remove the .pdb file which does not have an associated .trb file in the {cfg.rfdiff_out_path} directory, then run the computation again.")
+            raise Exception(f"Number of RfDiff .pdb files does not match RfDiff .trb files!") 
+        #endif
+        log.info("***************Skipping RFdiffusion altogether***************")
+        return
+
+
     rfdiff_cmd_str = f"{cfg.python_path_rfdiff} {cfg.inference_path_rfdiff} \
           inference.output_prefix={cfg.rfdiff_out_path} \
           'contigmap.contigs={cfg.contig}' \

--- a/rfdiff_mpnn_af2_merged.py
+++ b/rfdiff_mpnn_af2_merged.py
@@ -149,7 +149,6 @@ def do_cycling(cfg):
     """
     log.info("Running do_cycling")
     start_cycle = get_checkpoint(cfg.output_dir, "cycle", 0)
-    is_af_corrupted = get_checkpoint(cfg.output_dir, "is_af_corrupted", 0)
     content_status = get_checkpoint(cfg.output_dir, "content_status", 0) # 0 ... fresh run; 1 ... can clear and copy; 2 ... can copy; 3 ... corrupted (partial new files in AF2)
     for cycle in range(start_cycle, cfg.af2_mpnn_cycles):
         print("cycleeeeee", cycle)
@@ -502,7 +501,8 @@ def prosculptApp(cfg: DictConfig) -> None:
     general_config_prep(cfg)
     config = HydraConfig.get()
     config_name = config.job.config_name
-    config_path = [path["path"] for path in config.runtime.config_sources if path["schema"] == "file"][1]
+    log.info(f"config.runtime.config_sources: {config.runtime.config_sources}")
+    config_path = [path["path"] for path in config.runtime.config_sources if path["schema"] == "file"][-1] # If run without config (through cmd), [1] is out of range. Assume passed config file is always the last one.
     shutil.copy(os.path.join(config_path,config_name+'.yaml'), os.path.join(cfg.output_dir, f"input.yaml"))
 
     global crash_at_error

--- a/rfdiff_mpnn_af2_merged.py
+++ b/rfdiff_mpnn_af2_merged.py
@@ -106,7 +106,7 @@ def rechain_rfdiff_pdbs(cfg):
     rf_pdbs = glob.glob(os.path.join(cfg.rfdiff_out_path, '*.pdb'))
     for pdb in rf_pdbs:
         run_and_log(
-            f'{cfg.pymol_python_path} {scripts_folder / "rechain.py"} {pdb} {pdb} --chain_break_cutoff_A {cfg.chain_break_cutoff_A}'
+            f'{cfg.pymol_python_path} {scripts_folder / "rechain.py"} "{pdb}" "{pdb}" --chain_break_cutoff_A {cfg.chain_break_cutoff_A}'
         )
         
 

--- a/rfdiff_mpnn_af2_merged.py
+++ b/rfdiff_mpnn_af2_merged.py
@@ -216,7 +216,7 @@ def do_cycling(cfg):
                                     #itr_ -> to differentiate models in later cycles (5 pdbs for model 4 from rf 0 for example)
                                     # is it maybe possible to filter best ranked by af2 from the itr numbers?
                         throw(9, cycle)
-                save_checkpoint(cfg.output_dir, "content_status", 3) ## AF folder is soon going to be in such a state that .pdb files should not be moved on restart (because you would have two different cycles in the same cycle_folder)
+                save_checkpoint(cfg.output_dir, "content_status", 3) ## ProteinMPNN is quick and can be rerun until AF2 starts running
                 content_status = 3
 
             input_mpnn = cycle_directory
@@ -298,8 +298,8 @@ def do_cycling(cfg):
                 os.makedirs(monomers_fasta_dir)
             
             #if symmetry - make fasta file with monomer sequence only
-            for fasta_file in fasta_files:
-                if cfg.inference.symmetry!=None or cfg.get("model_monomer", False):  #TODO: move this up one line because cfg symmetry is constant, not based on fasta_file
+            if cfg.inference.symmetry!=None or cfg.get("model_monomer", False):  #cfg symmetry is constant, not based on fasta_file
+                for fasta_file in fasta_files:
                     sequences=[]
                     for record in SeqIO.parse(fasta_file, "fasta"):
                         record.seq = record.seq[:record.seq.find('/')]  
@@ -311,7 +311,7 @@ def do_cycling(cfg):
                     SeqIO.write(sequences, os.path.join(os.path.dirname(fasta_file), "monomers", f"{os.path.basename(fasta_file)[:-3]}_monomer.fa"), "fasta") # It must be written to the correct subfolder already to prevent duplication on job restart (CHECKPOINTING): _monomer_monomer.fa
                     print("File written to /monomers subfolder. "+fasta_file) #just for DEBUG 
                     ## CHECKPOINTING: Right now, protMPNN is rerun after restart, which outputs different files into mpnn_out. The new files overwrite the old ones in /monomers, so it is always fresh.
-                    ## TODO: skip it (need more state variable checkpoints)
+                    ## Unles AF2 already started running -- then it is skipped.
                     throw(16, cycle)
 
         # content_status = 4; everything up to here can be skipped

--- a/rfdiff_mpnn_af2_merged.py
+++ b/rfdiff_mpnn_af2_merged.py
@@ -137,7 +137,7 @@ def get_checkpoint(folder, piece, default=0):
     if os.path.exists(os.path.join(folder, f"checkpoint_{piece}.txt")):
         with open(os.path.join(folder, f"checkpoint_{piece}.txt"), "r") as f:
             value = int(f.read() or 0)
-            log.info(f"Reading checkpoint {piece} at cycle {value}")
+            log.info(f"Reading checkpoint {piece}: {value}")
             return value # suppose only numbers (as strings) are there (user should not write to this file). In worst case, file is empty.
     else:
         log.info(f"Checkpoint {piece} doesn't exist. Returning default value {default}")
@@ -401,7 +401,7 @@ def do_cycling(cfg):
         content_status = 1
 
         # msa single sequence makes sense for designed proteins
-    throw(21, cycle)
+    throw(21)
 
 def final_operations(cfg):
     log.info("Final operations")

--- a/rfdiff_mpnn_af2_merged.py
+++ b/rfdiff_mpnn_af2_merged.py
@@ -132,11 +132,22 @@ def parse_additional_args(cfg, group):
     return(dodatniArgumenti)
 
 error_messages = ["blank", "Am Anfang", "Just before entering next cycle (before deleting cycle_dir)", "Deleted cycle_dir, then crashed. New wasn't created yet.", "New empty cycle_dir, but is_af_corrupted=1", "New empty cycle_dir and is_af_corrupted=0", "Empty cycle_dir, just after saving is_af_corrupted=0", "Now created a dir, but haven't saved is_af_corrupted to 0 yet.", "Created dir & set is_af_corrupted to 0.", "9: This one is nasty! Already moved from af to cycle_dir, but haven't saved iteration number yet. After restart, one file will be lost (overwritten). TODO: Use alternative checkpointing.", "10: Moved and saved iteration number.", "Removed MPNN dir", "After parse_multiple_cahins", "After proteinMPNN", "Saved is_af_corrupted to 1, but haven't removed the af dir yet", "15: AF is now corrupted and empty.", "One file written to /monomers. On restart, will it overwrite it with the same one?", "Uh-oh, it crashed just prior to running AF.", "18: Now it crashed just after running AF for one fasta file.", "19: Well, now it crashed after running AF for all fasta files. But before saving cycle checkpoint! Expected restart result: just re-run it, without copying/moving anything in the cycle_dir", "20: Crashed just before updating cycle checkpoint.", "21: Finished all cycles; before final_ops"]
+import random
 def throw(id, cycle=0):
+    """
+    For testing restartability. Call it at different points in the code to see if the restart works.
+    @param id: int, ID of the crash you want to perform
+    @param cycle: int, in which AF-MPNN cycle should it crash
+    Message is derived from error_messages array. 
+    Alternatively, use probability-based crash test, which also re-runs the hard-coded command.
+    """
     log.info(f"Wanna crash? {id} ?= {crash_at_error} in cycle {cycle} ?= {crash_at_cycle}")
-    if id == crash_at_error and cycle == crash_at_cycle:
+    #if id == crash_at_error and cycle == crash_at_cycle:
+    if random.random() > 8/9:
         msg = error_messages[id]
         log.critical(f"Forced crash at {id}: {msg} in cycle {cycle}")
+        log.info("Re-running the command: ")
+        run_and_log("""python slurm_runner.py 1 MP_inpaintseq_CONT  output_dir="Examples/Examples_out/inpaintseq_MP_CONT" +throw=-16 +crash_at_cycle=0 -cd Examples -cn multipass_inpaintseq""")
         raise Exception(f"Forced crash at {id}: {msg} in cycle {cycle}") 
 
 def save_checkpoint(folder, piece, value):

--- a/run_tests.py
+++ b/run_tests.py
@@ -42,8 +42,12 @@ for test_file in test_file_list:
             if "Submitted batch job" in line:
                 print(line)
                 slurm_job_list.append(line.split("job ")[1])
+        if process_output.returncode!=0:
+            print(f"ERROR {test_file}:")
+            for line in process_output.stderr.split("\n"):
+                print(line)
 
-#print(slurm_job_list)
+print(f"Slurm job list: {slurm_job_list}")
 #Queue up the test verifier after all jobs have ended
 jobs_string=""
 for id, job in enumerate(slurm_job_list):

--- a/run_tests.py
+++ b/run_tests.py
@@ -56,7 +56,7 @@ for id, job in enumerate(slurm_job_list):
         
 #subprocess.run(command)
 if not args.dry_run:
-    os.system(f"sbatch -d afterany{jobs_string} -J test_check slurm_verify_tests.sh")
+    os.system(f"sbatch -d afterany{jobs_string} -J test_check --exclude=compute-0-5 slurm_verify_tests.sh") # compute-0-5 fails to run python (command not found, although PATH is correct)
     
 
 with open("Examples/Examples_out/test_verification_output.txt","w+") as output_file:

--- a/scripts/rechain.py
+++ b/scripts/rechain.py
@@ -44,8 +44,8 @@ def get_chainbreaks(objname_or_file, cutoff_A=2, cmd=None, delete_all_before_loa
     C_atoms = cmd.get_coords(objname+" and name C", 1)
     N_atoms = cmd.get_coords(objname+" and name N", 1)
     print(objname)
-    print(C_atoms[:-1])
-    print(N_atoms[1:])
+    #print(C_atoms[:-1])
+    #print(N_atoms[1:])
     #subastract the C from the N of the next residue
     distances = np.sum((C_atoms[:-1]-N_atoms[1:])**2, axis=1)
     #len(distances), min(distances), np.mean(distances) ,max(distances)

--- a/slurm_runner.py
+++ b/slurm_runner.py
@@ -5,7 +5,7 @@ import os
 import argparse
 import yaml
 
-parser=argparse.ArgumentParser(epilog=('#### Any other arguments passed will be passed as they are to prosculpt. If including output_dir, please include it first ####\n'))
+parser=argparse.ArgumentParser(epilog=('#### Any other arguments passed will be passed as they are to prosculpt. If including output_dir, please include it first ####\n**** Important: hydra config overrides should be put before -cd and -cn ****\nExample: python slurm_runner.py 1 multipassinpaintseq_throw  output_dir="Examples/Examples_out/multipass_inpaintseq_throw" +throw=1 +cycle=0 -cd Examples -cn multipass_inpaintseq'))
 
 parser.add_argument('num_tasks', help='Number of concurrent jobs to run.')
 parser.add_argument('name', help='Desired task name')

--- a/slurm_runner.py
+++ b/slurm_runner.py
@@ -66,7 +66,7 @@ print(f"Slurm command can be found in {out_command_file}")
 
 if not args[0].dry_run:
     #Exclude is there because that node was working incredibly slow
-    os.system(f"export GROUP_SIZE=1; sbatch --partition=gpu --gres=gpu:A40:1 --ntasks=1 --cpus-per-task=2 --output slurm-%A_%a_{task_name}.out --error slurm-%A_%a_{task_name}.out -J {task_name}  -a 1-{n} {slurm_runner_path}/wrapper_slurm_array_job_group.sh {out_command_file}")
+    os.system(f"export GROUP_SIZE=1; sbatch --exclude=compute-0-11 --partition=gpu --gres=gpu:A40:1 --ntasks=1 --cpus-per-task=2 --output slurm-%A_%a_{task_name}.out --error slurm-%A_%a_{task_name}.out -J {task_name}  -a 1-{n} {slurm_runner_path}/wrapper_slurm_array_job_group.sh {out_command_file}")
     print(f"Job {task_name} has been submitted to slurm".center(WIDTH, SYMBOL))
 else:
     print("Command wasn't run because --dry-run was active.")

--- a/slurm_verify_tests.sh
+++ b/slurm_verify_tests.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 echo "Hello from job $SLURM_JOB_ID on $(hostname) at $(date). I am verifying the tests."
+echo $PATH 
 python verify_tests.py Examples/Examples_out/

--- a/slurm_verify_tests.sh
+++ b/slurm_verify_tests.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+echo "Hello from job $SLURM_JOB_ID on $(hostname) at $(date). I am verifying the tests."
 python verify_tests.py Examples/Examples_out/

--- a/verify_tests.py
+++ b/verify_tests.py
@@ -22,13 +22,13 @@ with open(os.path.join(directory,"test_verification_output.txt"), "a+") as outpu
             print("test_folder is not final_pdbs")
             if os.path.isdir(os.path.join(directory,test_folder)):
                 print("test_folder is a directory")
-                if os.path.isdir(os.path.join(directory,test_folder,"00")): #Check if 00 folder exists. Not sure what triggers this folder to exist or not.
+                if os.path.isdir(os.path.join(directory,test_folder,"01")): #Check if 00 folder exists. Not sure what triggers this folder to exist or not.
                     ## ANSWER: Folder number is defined in slurm_runner.py where writing out_command_file (it overwrites the output_dir specified in config, by adding the number. I think it is necessary for making multiple models parallelly). 
                     ## This folder is then created in rfdiff_mpnn_af2_merged.py general_config_prep(), which is the first function called in the script.
-                    print("00 folder exists")
-                    final_output_path=os.path.join(directory,test_folder,"00","final_output.csv")
+                    print("01 folder exists")
+                    final_output_path=os.path.join(directory,test_folder,"01","final_output.csv")
                 else:
-                    print("00 folder does not exist")
+                    print("01 folder does not exist")
                     final_output_path=os.path.join(directory,test_folder,"final_output.csv")
                     
                 #final_pdbs_path=os.path.join(directory,test_folder,"final_pdbs")

--- a/verify_tests.py
+++ b/verify_tests.py
@@ -1,7 +1,10 @@
+print("Is this even working?", flush=True)
 import argparse
 import os
 import pandas as pd 
 import datetime
+
+print("Running test verification script: "+datetime.datetime.now().strftime('%d/%m/%y %H:%M:%S.%f'))
 
 parser=argparse.ArgumentParser()
 parser.add_argument("dir", help='Directory of test outputs.')
@@ -9,20 +12,29 @@ args=parser.parse_args()
 
 directory=args.dir
 
+print(f"Verifying tests in {directory}")
+
 with open(os.path.join(directory,"test_verification_output.txt"), "a+") as output_file:
+    print("Opened test_verification_output.txt")
     for test_folder in os.listdir(directory):
+        print(f"test_folder: {test_folder}")
         if test_folder!="final_pdbs":
+            print("test_folder is not final_pdbs")
             if os.path.isdir(os.path.join(directory,test_folder)):
+                print("test_folder is a directory")
                 if os.path.isdir(os.path.join(directory,test_folder,"00")): #Check if 00 folder exists. Not sure what triggers this folder to exist or not.
                     ## ANSWER: Folder number is defined in slurm_runner.py where writing out_command_file (it overwrites the output_dir specified in config, by adding the number. I think it is necessary for making multiple models parallelly). 
                     ## This folder is then created in rfdiff_mpnn_af2_merged.py general_config_prep(), which is the first function called in the script.
+                    print("00 folder exists")
                     final_output_path=os.path.join(directory,test_folder,"00","final_output.csv")
                 else:
+                    print("00 folder does not exist")
                     final_output_path=os.path.join(directory,test_folder,"final_output.csv")
                     
                 #final_pdbs_path=os.path.join(directory,test_folder,"final_pdbs")
 
                 if os.path.exists(final_output_path):
+                    print(f"final_output exists and is {final_output_path}")
                     #This part is commented because it was failing with the binders test because of folder architecture.
                     #final_output=pd.read_csv(final_output_path)
                     #if len(final_output)==len(os.listdir(final_pdbs_path)):
@@ -33,6 +45,9 @@ with open(os.path.join(directory,"test_verification_output.txt"), "a+") as outpu
                     
                     output_file.write("Test " + test_folder + " passed.\n")
                 else:
+                    print("final_output does not exist")
                     output_file.write("Test "+ test_folder + " failed. Missing final_output.csv\n")
 
+    print("penultimate line")
     output_file.write("Finished running and verifying tests: "+datetime.datetime.now().strftime('%d/%m/%y %H:%M:%S.%f')+"\n")
+print("Finished running test verification script: "+datetime.datetime.now().strftime('%d/%m/%y %H:%M:%S.%f'))

--- a/verify_tests.py
+++ b/verify_tests.py
@@ -14,6 +14,8 @@ with open(os.path.join(directory,"test_verification_output.txt"), "a+") as outpu
         if test_folder!="final_pdbs":
             if os.path.isdir(os.path.join(directory,test_folder)):
                 if os.path.isdir(os.path.join(directory,test_folder,"00")): #Check if 00 folder exists. Not sure what triggers this folder to exist or not.
+                    ## ANSWER: Folder number is defined in slurm_runner.py where writing out_command_file (it overwrites the output_dir specified in config, by adding the number. I think it is necessary for making multiple models parallelly). 
+                    ## This folder is then created in rfdiff_mpnn_af2_merged.py general_config_prep(), which is the first function called in the script.
                     final_output_path=os.path.join(directory,test_folder,"00","final_output.csv")
                 else:
                     final_output_path=os.path.join(directory,test_folder,"final_output.csv")

--- a/wrapper_slurm_array_job_group.sh
+++ b/wrapper_slurm_array_job_group.sh
@@ -13,6 +13,7 @@ do
     echo "Hello from job $SLURM_JOB_ID on $(hostname) at $(date)"
     echo "PWD:"
     pwd
+    echo "which python? $(which python)"
     echo ""
     J=$(($SLURM_ARRAY_TASK_ID * $GROUP_SIZE + $I - $GROUP_SIZE))
     CMD=$(sed -n "${J}p" $1)


### PR DESCRIPTION
This PR adds checkpointing to Prosculpt (fixes #17). This allows the jobs to be restartable in case of a crash/power outage/backfilling.

The following situations are considered:
1.	Crash during RfDiff: RfDiff handles this and only generates missing models
2.	Crash after RfDiff: based on number of .pdb and .trb files, we skip RfDiff altogether (no need to wait for it to load all parameters)
3.	Crash during ProteinMPNN: it runs it again, producing new output. It is so fast we can leave it as-is
4.	Crash after ProteinMPNN: operations before AF2 are skipped
5.	Crash during AF2: AF2 handles this and only generates missing models (per fasta sequence)
6.	Crash during moving files to cycle_directory: continue where it stopped
7.	Crash during various AF2-MPNN cycles: continue from that cycle
8.	Crash after the last cycle: skip operations before final_operations
9.	Crash during final_operations: re-run final_operations
10.	Crash after final_operations: the job has finished by then, should not be in the restart-queue anymore. Nevertheless, if restarted, it will re-run final_oprations


Additionally, this PR fixes #20 which incorrectly deleted some models during AF2-MPNN cycling.
