### PR TITLE
Fix for multi-chain targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,13 @@ Contigs are the most important input (for now, guiding potentials are another in
 In case of errors in any of the sub programs (RfDiffusion, ProteinMPNN, AlphaFold) prosculpt can automatically restart, so that the previous steps are not lost.
 To do so, pass `auto_restart: n`, where `n` ... number of allowed restarts, to the .yaml config.
 
+## Caveats/Troubleshooting
+### Binder design
+* In the input pdb, target must start with chain `B`, and use subsequent chain letters (C, D ...) if it has multiple chains. 
+    * Otherwise, errors arise when passing into ProteinMPNN.
+* Targets should not have missing residues s. t. distance between two residues would be larger than `chain_break_cutoff_A`
+    * Otherwise, rechain.py will start a new chain at that point, causing errors when passing into ProteinMPNN.
+    * Note that even without missing residues, calculated distance after the RfDiffusion step may sometimes be just slightly above 2 Å around prolines, so adjust accordingly. 
+* The `chains_to_design` parameter should not be present at all in the .yaml config file! 
+    * Otherwise, target will be fixed incorrectly and thus its aminoacids changed. 
+

--- a/prosculpt.py
+++ b/prosculpt.py
@@ -1905,15 +1905,18 @@ def process_pdb_files(pdb_path: str, out_path: str, cfg, trb_paths=None, cycle=0
         print(f"Fixed res (according to contig chain breaks): {fixed_res}")
 
         # This is only good if multiple chains due to symmetry: all of them are equal; ProteinMPNN expects fixed_res as 1-based, resetting for each chain.
+        
+        # Fix for multi-chain receptors 
+        complex_con_ref_pdb_idx = trb_data.get('complex_con_ref_pdb_idx', con_hal_idx.copy()) # If not present, it will act as in older versions.
 
-        for chain, idx in con_hal_idx:
+        for (chain, idx), (chain_from_input, idx_from_input) in zip(con_hal_idx, complex_con_ref_pdb_idx):
             # If there are multiple chains, reset the auto_incrementing numbers to 1 for each chain (subtract offset)
             if not skipRfDiff:
                 if trb_data["inpaint_seq"][
                     idx - 1
                 ]:  # skip residues with FALSE in the inpaint_seq array
-                    fixed_res.setdefault(chain, list()).append(
-                        idx - chainResidOffset[chain]
+                    fixed_res.setdefault(chain_from_input, list()).append(
+                        idx - chainResidOffset[chain_from_input]
                     )
             else:
                 fixed_res.setdefault(chain, list()).append(


### PR DESCRIPTION
This fix correctly handles multiple chains in targets when designing binders.

Previously, if the target had more than one chain, Prosculpt would throw an error either within ProteinMPNN (which would always try to acces chain B, but after rechaining.py, some residues were renamed into chain C) or later within parse_pdb, process_pdb, calculate_RMSD functions of Prosculpt.

The new code uses chain latters as in the input .pdb file.

**Note**: This means that the target _must_ start with chain B and use subsequent letters for more chains.

All automated tests (excluding AF3 and Boltz) have passed successfully, and I've also manually confirmed that outputs are the same as in the previous version.